### PR TITLE
debuild warning fix: potentially unsafe /tmp usage

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,7 +20,7 @@ set -e
 
 case "$1" in
 	configure)
-		TMPDIR="/tmp/dpkg.wlinux-base.inst"
+		TMPDIR="/run/dpkg.wlinux-base.inst"
 
 		if [ -f "${TMPDIR}/profile" ] ; then
 			echo "Moving new profile into /etc"

--- a/debian/preinst
+++ b/debian/preinst
@@ -48,11 +48,11 @@ case "$1" in
 			echo " Done!"
 
 			echo "Removing old /etc/os-release and placing default symlink"
-			mv /etc/os-release "${TMPDIR}/os-release"
+			mv /etc/os-release "${TMPDIR}"
 			ln -s /usr/lib/os-release /etc/os-release
 
 			echo "Making copy of /etc/sudoers"
-			cp /etc/sudoers "${TMPDIR}/sudoers"
+			cp /etc/sudoers "${TMPDIR}"
 			fi
 			fi
 		else
@@ -62,7 +62,7 @@ case "$1" in
 			echo 'Defaults lecture_file = /etc/sudoers.lecture' >> "${TMPDIR}/sudoers"
 
 			if [ -f "/etc/sudoers.lecture" ] ; then
-				cp /etc/sudoers.lecture /tmp/dpkg.wlinux-base
+				cp /etc/sudoers.lecture "${TMPDIR}"
 			fi
 			echo 'Enter your UNIX password below. This is not your Windows password.' >> "${TMPDIR}/sudoers.lecture"
 		fi

--- a/debian/preinst
+++ b/debian/preinst
@@ -16,7 +16,7 @@ set -e
 
 case "$1" in
 	install)
-		TMPDIR="/tmp/dpkg.wlinux-base.inst"
+		TMPDIR="/run/dpkg.wlinux-base.inst"
 
 		# Ensure all necessary filesystem directories exist
 		mkdir -p /etcfonts


### PR DESCRIPTION
Have switched from using /tmp to using /run as our temporary directory during preinst and postinst. /run is a newer tempfs that's intended for use by privileged processes so should be safer while fixing the warning too.

Ideally we'd be using a randomised directory provided by `mktemp -d` but unfortunately I haven't found a way of passing this variable between the two scripts yet. So something to keep in mind for the future.