### PR TITLE
Legacy path fix

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -44,7 +44,7 @@ case "$1" in
 			echo "Backing up current profile"
 			cp /etc/profile /etc/profile.old
 			echo -n "Downloading default profile..."
-			curl "https://sources.debian.org/data/main/b/base-files/10.1/share/profile" -so "${TMPDIR}/profile"
+			curl "https://salsa.debian.org/rhaist-guest/WSL/raw/master/linux_files/profile" -so "${TMPDIR}/profile"
 			echo " Done!"
 
 			echo "Removing old /etc/os-release and placing default symlink"

--- a/profile.d/00-wlinux.sh
+++ b/profile.d/00-wlinux.sh
@@ -1,14 +1,3 @@
-# WSL
-IS_WSL=`grep -i microsoft /proc/version`
-if test "$IS_WSL" = ""; then
-  if [ "`id -u`" -eq 0 ]; then
-    PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-  else
-    PATH="/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games"
-  fi
-fi
-export PATH
-
 # enable external x display
 export DISPLAY=:0
 


### PR DESCRIPTION
- Modify debian/preinst to download default profile from Debian's WSL Gitlab repo, as opposed to a Debian regular Linux install profile [previously this was causing issues with PATH not having correct value, missing all of Windows related paths]
- Remove code from 00-wlinux.sh that is actually automatically included in profile