### PR TITLE
Add essential flag to wlinux-base package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,3 +12,4 @@ Package: wlinux-base
 Architecture: all
 Depends: ${misc:Depends}, curl, apt-transport-https, whiptail, gnupg
 Description: Base modifications for WLinux
+Essential: yes


### PR DESCRIPTION
Marks package as essential such that the user is asked `You are about to do something potentially harmful.
To continue type in the phrase 'Yes, do as I say!'`.

Have ran tests on my own build and all seems to work fine, and works the same as any other essential package e.g. bash